### PR TITLE
Develop 0.2.5

### DIFF
--- a/lib/narou.ex
+++ b/lib/narou.ex
@@ -12,7 +12,7 @@ defmodule Narou do
   alias Narou.Client
   alias Narou.QueryBuilder
   alias Narou.ResultFormatter, as: Formatter
-  alias Narou.Entity, as: S
+  alias Narou.Entity
 
   defmacro __using__(_opt) do
     quote do
@@ -49,12 +49,7 @@ defmodule Narou do
       }
 
   """
-  def init(opt \\ [type: :novel]) do
-    case S.init(opt) do
-      {:ok, s}    -> s
-      {:error, m} -> {:error, m}
-    end
-  end
+  def init(opt \\ [type: :novel]), do: Entity.init(opt)
 
   @doc """
       APIサーバへリクエストする。

--- a/lib/narou/entity.ex
+++ b/lib/narou/entity.ex
@@ -3,6 +3,8 @@ defmodule Narou.Entity do
 APIデータの基底モジュール。
 """
 
+  import Narou.Util
+
 @doc """
 APIデータの共通処理。
 
@@ -124,11 +126,7 @@ APIデータの共通処理。
   end
 
   def valid_select?(cols) do
-    cols |> Enum.all?(&is_symbol?/1)
-  end
-
-  defp is_symbol?(val) do
-    is_atom(val) && Regex.match?(~r/^[a-z\d]{1,}([a-z\d\_]*[a-z\d]{1,})*$/, to_string(val))
+    cols |> Enum.all?(&is_symbol/1)
   end
 
   def to_map_for_build_query(entity), do: Map.drop(entity, to_submodule(entity.type).__drop_keys__)

--- a/lib/narou/entity/rank.ex
+++ b/lib/narou/entity/rank.ex
@@ -20,13 +20,9 @@ defmodule Narou.Entity.Rank do
     {%{y: year, m: month, d: day, t: type}, other} = Map.split(map, [:y, :m, :d, :t])
 
     cond do
-      map_size(other) > 0 ->
-        keys = Map.keys(other) |> Enum.map(&(":#{&1}")) |> Enum.join(", ")
-        {:error, "Unexpected keys [#{keys}]"}
+      map_size(other) > 0 -> {:error, "Unexpected keys [#{inspect(Map.keys(other))}]"}
 
-      !Enum.member?(@rank_types, type) ->
-        types = @rank_types |> Enum.map(&(":#{&1}")) |> Enum.join(", ")
-        {:error, "must be one of [#{types}]"}
+      !Enum.member?(@rank_types, type) -> {:error, "must be one of [#{inspect(@rank_types)}]"}
 
       true -> case Date.new(year, month, day) do
         {:ok, _}    -> true

--- a/lib/narou/entity/rankin.ex
+++ b/lib/narou/entity/rankin.ex
@@ -13,16 +13,11 @@ defmodule Narou.Entity.Rankin do
     {%{ncode: ncode}, other} = Map.split(map, [:ncode])
 
     cond do
-      map_size(other) > 0 ->
-        keys = Map.keys(other) |> Enum.map(&(":#{&1}")) |> Enum.join(", ")
-        {:error, "Unexpected keys [#{keys}]"}
+      map_size(other) > 0 -> {:error, "Unexpected keys [#{inspect(Map.keys(other))}]"}
 
-      true ->
-        if is_ncode(ncode) do
-          true
-        else
-          {:error, "invalid NCode `#{ncode}`."}
-        end
+      !is_ncode(ncode) -> {:error, "invalid NCode `#{ncode}`."}
+
+      true -> true
     end
   end
 end

--- a/lib/narou/util.ex
+++ b/lib/narou/util.ex
@@ -39,4 +39,6 @@ UtilityModule.
 
   @spec end_point() :: binary
   def end_point(), do: Narou.Client.init.endpoint
+
+  def is_symbol(val), do: is_atom(val) && Regex.match?(~r/^:.*$/, inspect(val))
 end

--- a/spec/lib/narou_entity_spec.exs
+++ b/spec/lib/narou_entity_spec.exs
@@ -9,11 +9,10 @@ defmodule NarouEntitySpec do
       let :rankin, do: Narou.Entity.init(type: :rankin)
       let :user  , do: Narou.Entity.init(type: :user)
 
-      it do: expect novel()  |> to(be_ok_result())
-      it do: expect novel()  |> elem(1) |> to(have __struct__: Narou.Entity.Novel)
-      it do: expect rank()   |> elem(1) |> to(have __struct__: Narou.Entity.Rank)
-      it do: expect rankin() |> elem(1) |> to(have __struct__: Narou.Entity.Rankin)
-      it do: expect user()   |> elem(1) |> to(have __struct__: Narou.Entity.User)
+      it do: expect novel()  |> to(have __struct__: Narou.Entity.Novel)
+      it do: expect rank()   |> to(have __struct__: Narou.Entity.Rank)
+      it do: expect rankin() |> to(have __struct__: Narou.Entity.Rankin)
+      it do: expect user()   |> to(have __struct__: Narou.Entity.User)
     end
 
     context "bad" do

--- a/spec/narou_query_spec.exs
+++ b/spec/narou_query_spec.exs
@@ -3,7 +3,7 @@ defmodule NarouQuerySpec do
   use Narou.Query
 
   describe "from" do
-    context "from good_param" do
+    context "from init & exec query" do
       let :q, do: from(:novel)
       let :with_opt, do: from(:novel, limit: 10, st: 10)
       let :with_query, do: from(:novel, select: [:t], where: [ncode: "n2267be"], order: :old)
@@ -16,6 +16,15 @@ defmodule NarouQuerySpec do
       it do: expect with_query() |> to(have select: [:t])
       it do: expect with_query() |> to(have where:  %{ncode: "n2267be"})
       it do: expect with_query() |> to(have order:  :old)
+    end
+
+    context "from extend query" do
+      let! :base_query, do: from(:novel)
+      let! :extended_query, do: from(base_query(), limit: 10, select: :t)
+
+      it do: expect extended_query() |> to(have type: :novel)
+      it do: expect extended_query() |> to(have limit: 10)
+      it do: expect extended_query() |> to(have select: [:t])
     end
   end
 


### PR DESCRIPTION
* from/2 クエリを継承できるように変更
```elixir
import Narou.Query

base_query = from :novel

q1 = from(base_query, select: [:t])
# %Narou.Entity.Novel{
#   limit: 20,
#   maximum_fetch_mode: false,
#   order: :new,
#   out_type: :json,
#   select: [:t],
#   st: 1,
#   type: :novel,
#   where: %{}
# }

q2 = from(base_query, where: [ncode: "n2267be"])
# %Narou.Entity.Novel{
#   limit: 20,
#   maximum_fetch_mode: false,
#   order: :new,
#   out_type: :json,
#   select: [],
#   st: 1,
#   type: :novel,
#   where: %{ncode: "n2267be"}
# }
```